### PR TITLE
<RDKBDEV-866>, <RDKBDEV-1018> : Add Device.WiFi mapper

### DIFF
--- a/scripts/RdkEasyMeshController.xml
+++ b/scripts/RdkEasyMeshController.xml
@@ -223,6 +223,12 @@
               <writable>true</writable>
             </parameter>
             <parameter>
+              <name>Enable</name>
+              <type>boolean</type>
+              <syntax>bool</syntax>
+              <writable>true</writable>
+            </parameter>
+            <parameter>
               <name>Extender</name>
               <type>boolean</type>
               <syntax>bool</syntax>

--- a/source/cosa_emctl_apis.h
+++ b/source/cosa_emctl_apis.h
@@ -64,6 +64,9 @@
 #ifndef COSA_EMCTL_MAX_PROFILES_COUNT
 #define COSA_EMCTL_MAX_PROFILES_COUNT       16
 #endif
+#ifndef COSA_EMCTL_MAX_RADIO_COUNT
+#define COSA_EMCTL_MAX_RADIO_COUNT          2
+#endif
 #ifndef COSA_EMCTL_MAX_FREQUENCY_BANDS_LEN
 #define COSA_EMCTL_MAX_FREQUENCY_BANDS_LEN  17
 #endif
@@ -92,8 +95,7 @@
 #define COSA_EMCTL_MAX_CHANNEL_SET          192
 #endif
 
-typedef struct
-{
+typedef struct {
     char *type;
     unsigned int index;
     char *value;
@@ -104,9 +106,11 @@ typedef int (*cb_func_t)(queue_t *);
 struct _COSA_DML_EMCTL_PROFILE_CFG {
     BOOL    Backhaul;
     BOOL    Extender;
+    BOOL    Enable;
     char    FrequencyBands[COSA_EMCTL_MAX_FREQUENCY_BANDS_LEN];
     BOOL    Fronthaul;
     BOOL    Gateway;
+    int     Indices[COSA_EMCTL_MAX_RADIO_COUNT];
     char    KeyPassphrase[COSA_EMCTL_MAX_WIFI_PASSWORD_LEN];
     char    Label[COSA_EMCTL_MAX_PROFILE_LABEL_LEN];
     char    SecurityMode[COSA_EMCTL_MAX_SECURITY_MODE_LEN];
@@ -175,6 +179,7 @@ int CosaEmctlGetTopologyQueryInterval(unsigned int *value);
 int CosaEmctlTopologyStableCheckInterval(unsigned int *value);
 
 int CosaEmctlProfileGetBackhaul(uint8_t index, bool *bh);
+int CosaEmctlProfileGetEnable(uint8_t index, bool *enable);
 int CosaEmctlProfileGetExtender(uint8_t index, uint8_t *extender);
 int CosaEmctlProfileGetFrequencyBands(uint8_t index, char **freq_bands);
 int CosaEmctlProfileGetFronthaul(uint8_t index, bool *fh);

--- a/source/cosa_emctl_dml.c
+++ b/source/cosa_emctl_dml.c
@@ -1160,6 +1160,10 @@ SSIDProfile_GetParamBoolValue
         *pBool = pProfile->Backhaul;
         return TRUE;
     }
+    if (AnscEqualString(pParamName, "Enable", TRUE)) {
+        *pBool = pProfile->Enable;
+        return TRUE;
+    }
     if (AnscEqualString(pParamName, "Extender", TRUE)) {
         *pBool = pProfile->Extender;
         return TRUE;
@@ -1376,6 +1380,13 @@ SSIDProfile_SetParamBoolValue
             return TRUE;
         }
         pProfile->Backhaul = TRUE;
+        return TRUE;
+    }
+    if (AnscEqualString(pParamName, "Enable", TRUE)) {
+        if (pProfile->Enable == bValue) {
+            return TRUE;
+        }
+        pProfile->Enable = TRUE;
         return TRUE;
     }
     if (AnscEqualString(pParamName, "Extender", TRUE)) {

--- a/source/cosa_emctl_dml.c
+++ b/source/cosa_emctl_dml.c
@@ -870,7 +870,7 @@ ChanSel_GetParamStringValue
 
     description:
 
-        This function is called to set bulk parameter values;
+        This function is called to set string parameter values;
 
     argument:   ANSC_HANDLE                 hInsContext,
                 The instance handle;
@@ -1430,7 +1430,7 @@ SSIDProfile_SetParamBoolValue
 
     description:
 
-        This function is called to set bulk parameter values;
+        This function is called to set string parameter values;
 
     argument:   ANSC_HANDLE                 hInsContext,
                 The instance handle;


### PR DESCRIPTION
Reason for change: Device.WiFi variables must be converted to
    SSIDProfiles for Easymesh Controller to operate properly. Both
    during initial bootup and after variable modifications.
Test Procedure: Use CLI or GUI to change SSID and/or KeyPassphrase.
Risks: Low

Signed-off-by: Engin Akca <engin.akca@airties.com>