### PR TITLE
RDKBDEV-1018 RDKBDEV-866 : Process CcspWifiAgent Notifications

### DIFF
--- a/scripts/RdkEasyMeshController.xml
+++ b/scripts/RdkEasyMeshController.xml
@@ -203,8 +203,10 @@
           <name>SSIDProfile</name>
           <objectType>dynamicTable</objectType>
           <functions>
-            <func_GetEntryCount>SSIDProfile_GetEntryCount</func_GetEntryCount>
             <func_GetEntry>SSIDProfile_GetEntry</func_GetEntry>
+            <func_GetEntryCount>SSIDProfile_GetEntryCount</func_GetEntryCount>
+            <func_IsUpdated>SSIDProfile_IsUpdated</func_IsUpdated>
+            <func_Synchronize>SSIDProfile_Synchronize</func_Synchronize>
             <func_GetParamBoolValue>SSIDProfile_GetParamBoolValue</func_GetParamBoolValue>
             <func_SetParamBoolValue>SSIDProfile_SetParamBoolValue</func_SetParamBoolValue>
             <func_GetParamStringValue>SSIDProfile_GetParamStringValue</func_GetParamStringValue>

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -23,18 +23,21 @@
 # Licensed under the Apache License, Version 2.0
 ##########################################################################
 
-AM_CPPFLAGS = -Wall -Werror -D_GNU_SOURCE
+AM_CFLAGS = -D_ANSC_LINUX
+AM_CFLAGS += -D_ANSC_USER
+AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
+AM_CFLAGS += $(DBUS_CFLAGS)
 
-AM_CPPFLAGS += -I$(top_srcdir)/hal/include \
-		-I$(top_srcdir)/source/ssp \
-		-I=${includedir} \
-		-I=${includedir}/ccsp
+AM_CFLAGS += -D_GNU_SOURCE
+AM_CFLAGS += -Wall -Wextra -Werror
 
-AM_CFLAGS = -D_ANSC_LINUX -D_ANSC_USER -D_ANSC_LITTLE_ENDIAN_ $(DBUS_CFLAGS)
-
-AM_LDFLAGS = -lsyscfg -lsysevent -lpthread -lccsp_common $(DBUS_LIBS) -llog4c
+ACLOCAL_AMFLAGS = -I m4
 
 noinst_LIBRARIES = libssp.a
+
+libssp_a_CFLAGS = -I$(top_srcdir)/source/ssp \
+                  -I=${includedir} \
+                  -I=${includedir}/ccsp
 
 libssp_a_SOURCES = $(srcdir)/collection.c \
                    $(srcdir)/cosa_emctl_dml.c \
@@ -43,3 +46,5 @@ libssp_a_SOURCES = $(srcdir)/collection.c \
                    $(srcdir)/ssp_action.c \
                    $(srcdir)/ssp_main.c \
                    $(srcdir)/ssp_mbi.c
+
+libssp_a_LDFLAGS = -lsyscfg -lsysevent -lpthread -lccsp_common $(DBUS_LIBS) -llog4c

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -35,9 +35,9 @@ ACLOCAL_AMFLAGS = -I m4
 
 noinst_LIBRARIES = libssp.a
 
-libssp_a_CFLAGS = -I$(top_srcdir)/source/ssp \
-                  -I=${includedir} \
-                  -I=${includedir}/ccsp
+libssp_a_CPPFLAGS = -I$(top_srcdir)/source/ssp \
+                    -I=${includedir} \
+                    -I=${includedir}/ccsp
 
 libssp_a_SOURCES = $(srcdir)/collection.c \
                    $(srcdir)/cosa_emctl_dml.c \
@@ -47,4 +47,5 @@ libssp_a_SOURCES = $(srcdir)/collection.c \
                    $(srcdir)/ssp_main.c \
                    $(srcdir)/ssp_mbi.c
 
-libssp_a_LDFLAGS = -lsyscfg -lsysevent -lpthread -lccsp_common $(DBUS_LIBS) -llog4c
+libssp_a_LDFLAGS = -lsyscfg -lsysevent -lpthread -lccsp_common -llog4c
+libssp_a_LDFLAGS += $(DBUS_LIBS)

--- a/source/cosa_emctl_apis.c
+++ b/source/cosa_emctl_apis.c
@@ -94,11 +94,11 @@ static COSA_DML_EMCTL_PROFILE_CFG g_default_profiles[] = {
     }
 };
 
-static int DmlEmctlGetParamValues(char *pathname, char *value, size_t valuesize)
+static ANSC_STATUS DmlEmctlGetParamValues(char *pathname, char *value, size_t valuesize)
 {
-    int ret = 0;
+    int ret;
     int i;
-    int retval = -1; // default failure
+    ANSC_STATUS retval = ANSC_STATUS_FAILURE; // default failure
     const char *subsystem_prefix = "eRT.";
     int size = 0;
     int size2 = 0;
@@ -138,7 +138,7 @@ static int DmlEmctlGetParamValues(char *pathname, char *value, size_t valuesize)
         if (size > 0) {
             if (val[0]->parameterValue && strlen(val[0]->parameterValue) != 0) {
                 snprintf(value, valuesize, "%s", val[0]->parameterValue);
-                retval = 0; // set success
+                retval = ANSC_STATUS_SUCCESS; // set success
             }
         }
         free_parameterValStruct_t (bus_handle, size, val);
@@ -175,11 +175,11 @@ next:
     return retval;
 }
 
-static int DmlEmctlSetParamValues(const char *pathname, enum dataType_e type, const char *value, int commit)
+static ANSC_STATUS DmlEmctlSetParamValues(const char *pathname, enum dataType_e type, const char *value, int commit)
 {
-    int ret = 0;
+    int ret;
     int i;
-    int retval = -1; // default failure
+    ANSC_STATUS retval = ANSC_STATUS_FAILURE; // default failure
     const char *subsystem_prefix = "eRT.";
     int size2 = 0;
     const char *dst_pathname_cr =  "eRT.com.cisco.spvtg.ccsp.CR";
@@ -300,7 +300,7 @@ static void get_mac_addresses(PCOSA_DML_EMCTL_CFG cfg)
     AnscCopyString(cfg->MACAddress, macstr);
 }
 
-static int wifi_get_radio_freqband(char *value, unsigned int index)
+static ANSC_STATUS wifi_get_radio_freqband(char *value, unsigned int index)
 {
     char path[512] = {0};
     char acTmpReturnValue[256] = {0};
@@ -322,10 +322,10 @@ static int wifi_get_radio_freqband(char *value, unsigned int index)
         strcpy(value, "2");
     }
 
-    return 0;
+    return ANSC_STATUS_SUCCESS;
 }
 
-static int wifi_get_ssid_count(unsigned int *value)
+static ANSC_STATUS wifi_get_ssid_count(unsigned int *value)
 {
     char path[64] = {0};
     char acTmpReturnValue[256] = {0};
@@ -337,10 +337,10 @@ static int wifi_get_ssid_count(unsigned int *value)
     }
     *value = (unsigned int)atoi(acTmpReturnValue);
 
-    return 0;
+    return ANSC_STATUS_SUCCESS;
 }
 
-static int wifi_get_ssid_enable(bool *value, unsigned int index)
+static ANSC_STATUS wifi_get_ssid_enable(bool *value, unsigned int index)
 {
     char path[64] = {0};
     char acTmpReturnValue[256] = {0};
@@ -356,10 +356,10 @@ static int wifi_get_ssid_enable(bool *value, unsigned int index)
         *value = false;
     }
 
-    return 0;
+    return ANSC_STATUS_SUCCESS;
 }
 
-static int wifi_get_ssid_ssid(char *value, unsigned int index)
+static ANSC_STATUS wifi_get_ssid_ssid(char *value, unsigned int index)
 {
     char path[64] = {0};
     char acTmpReturnValue[256] = {0};
@@ -371,10 +371,10 @@ static int wifi_get_ssid_ssid(char *value, unsigned int index)
     }
     AnscCopyString(value, acTmpReturnValue);
 
-    return 0;
+    return ANSC_STATUS_SUCCESS;
 }
 
-static int wifi_get_security_index(unsigned int *value, unsigned int index)
+static ANSC_STATUS wifi_get_security_index(unsigned int *value, unsigned int index)
 {
     char path[64] = {0};
     char acTmpReturnValue[256] = {0};
@@ -405,7 +405,7 @@ static int wifi_get_security_index(unsigned int *value, unsigned int index)
     return ANSC_STATUS_FAILURE;
 }
 
-static int wifi_get_security_keypassphrase(char *value, unsigned int index)
+static ANSC_STATUS wifi_get_security_keypassphrase(char *value, unsigned int index)
 {
     char path[64] = {0};
     char acTmpReturnValue[256] = {0};
@@ -417,10 +417,10 @@ static int wifi_get_security_keypassphrase(char *value, unsigned int index)
     }
     AnscCopyString(value, acTmpReturnValue);
 
-    return ANSC_STATUS_FAILURE;
+    return ANSC_STATUS_SUCCESS;
 }
 
-static int wifi_get_security_mode(char *value, unsigned int index)
+static ANSC_STATUS wifi_get_security_mode(char *value, unsigned int index)
 {
     char path[64] = {0};
     char acTmpReturnValue[256] = {0};
@@ -434,7 +434,7 @@ static int wifi_get_security_mode(char *value, unsigned int index)
         strcpy(value, "wpa2-psk");
     }
 
-    return ANSC_STATUS_FAILURE;
+    return ANSC_STATUS_SUCCESS;
 }
 
 static inline void profile_set_backhaul(PCOSA_DML_EMCTL_PROFILE_CFG profile)
@@ -475,7 +475,7 @@ static void device_wifi_dynamic_mapper(PCOSA_DML_EMCTL_CFG emctl)
     bool found;
     bool ssid_enable = false;
     bool dedicated_backhaul = true;
-    unsigned int ap_index;
+    unsigned int ap_index = 0;
     unsigned int ssid_count = 0;
     unsigned int ssid_index;
     unsigned int profile_count;
@@ -833,6 +833,24 @@ ANSC_STATUS CosaEmctlInitialize(ANSC_HANDLE hThisObject)
     return ANSC_STATUS_SUCCESS;
 }
 
+int CosaEmctlGetAllowedBandwidth2G(char *value)
+{
+    AnscCopyString(value, g_pEmctl_Cfg->AllowedBandwidth2G);
+    return 0;
+}
+
+int CosaEmctlGetAllowedBandwidth5G(char *value)
+{
+    AnscCopyString(value, g_pEmctl_Cfg->AllowedBandwidth5G);
+    return 0;
+}
+
+int CosaEmctlGetAllowedBandwidth6G(char *value)
+{
+    AnscCopyString(value, g_pEmctl_Cfg->AllowedBandwidth6G);
+    return 0;
+}
+
 int CosaEmctlGetAllowedChannelList2G(char *value)
 {
     AnscCopyString(value, g_pEmctl_Cfg->AllowedChannelList2G);
@@ -842,6 +860,12 @@ int CosaEmctlGetAllowedChannelList2G(char *value)
 int CosaEmctlGetAllowedChannelList5G(char *value)
 {
     AnscCopyString(value, g_pEmctl_Cfg->AllowedChannelList5G);
+    return 0;
+}
+
+int CosaEmctlGetAllowedChannelList6G(char *value)
+{
+    AnscCopyString(value, g_pEmctl_Cfg->AllowedChannelList6G);
     return 0;
 }
 
@@ -878,6 +902,12 @@ int CosaEmctlGetDeadAgentDetectionInterval(unsigned int *value)
 int CosaEmctlGetDefault2GPreferredChannelList(char *value)
 {
     AnscCopyString(value, g_pEmctl_Cfg->Default2GPreferredChannelList);
+    return 0;
+}
+
+int CosaEmctlGetDefault6GPreferredChannelList(char *value)
+{
+    AnscCopyString(value, g_pEmctl_Cfg->Default6GPreferredChannelList);
     return 0;
 }
 
@@ -1185,6 +1215,10 @@ static void profile_split(PCOSA_DML_EMCTL_CFG emctl, unsigned int profile_index,
     PCOSA_DML_EMCTL_PROFILE_CFG profile;
 
     profile = &emctl->SSIDProfiles[profile_index];
+    if (profile->Indices[0] < 0 || profile->Indices[1] < 0) {
+        return;
+    }
+
     dst = &emctl->SSIDProfiles[emctl->SSIDProfileNumberOfEntries];
     dst->Backhaul = profile->Backhaul;
     dst->Enable = profile->Enable;
@@ -1200,7 +1234,7 @@ static void profile_split(PCOSA_DML_EMCTL_CFG emctl, unsigned int profile_index,
 
     strcpy(bands, profile->FrequencyBands);
     band = strtok_r(bands, ",", &sp);
-    if (ssid_index == profile->Indices[0]) {
+    if (ssid_index == (unsigned int)profile->Indices[0]) {
         dst->Indices[0] = profile->Indices[1];
         strcpy(profile->FrequencyBands, band);
         band = strtok_r(NULL, ",", &sp);
@@ -1219,8 +1253,11 @@ static void profile_split(PCOSA_DML_EMCTL_CFG emctl, unsigned int profile_index,
     return;
 }
 
-static void profile_update(PCOSA_DML_EMCTL_CFG emctl, update_params_t *update)
+static int profile_update(PCOSA_DML_EMCTL_CFG emctl, update_params_t *update)
 {
+    char *value;
+    char *sec_type;
+    char *auth_mode;
     unsigned int ssid_index;
     PCOSA_DML_EMCTL_PROFILE_CFG check;
     PCOSA_DML_EMCTL_PROFILE_CFG profile;
@@ -1229,19 +1266,61 @@ static void profile_update(PCOSA_DML_EMCTL_CFG emctl, update_params_t *update)
     for (i = 0; i < emctl->SSIDProfileNumberOfEntries; i++) {
         profile = &emctl->SSIDProfiles[i];
         ssid_index = update->index + 1;
-        if (ssid_index != profile->Indices[0] && ssid_index != profile->Indices[1]) {
+        if (ssid_index != (unsigned int)profile->Indices[0] &&
+            ssid_index != (unsigned int)profile->Indices[1]) {
             continue;
         }
-        if (strcmp(update->type, "SSID") == 0) {
-            if (profile->Indices[0] >= 0 && profile->Indices[1] >= 0) {
-                profile_split(emctl, i, ssid_index);
+        if (strcmp(update->type, "SSIDEnable") == 0) {
+            profile_split(emctl, i, ssid_index);
+            if (strcmp(update->value, "0") == 0) {
+                profile->Enable = FALSE;
+            } else {
+                profile->Enable = TRUE;
             }
+        } else if (strcmp(update->type, "SSID") == 0) {
+            profile_split(emctl, i, ssid_index);
             strncpy(profile->SSID, update->value, sizeof(profile->SSID) - 1);
-        } else if (strcmp(update->type, "KeyPassphrase") == 0) {
-            if (profile->Indices[0] >= 0 && profile->Indices[1] >= 0) {
-                profile_split(emctl, i, ssid_index);
+        } else if (strcmp(update->type, "SecMode") == 0) {
+            profile_split(emctl, i, ssid_index);
+            /* Do not modify update */
+            value = strdup(update->value);
+            sec_type = value;
+            auth_mode = strchr(value, ';');
+            if (auth_mode) {
+                *(auth_mode++) = 0;
             }
+            if (strcmp(sec_type, "None") == 0) {
+                strcpy(profile->SecurityMode, "none");
+            } else if (strcmp(sec_type, "WPAand11i") == 0) {
+                if (strcmp(auth_mode, "PSKAuthentication") == 0) {
+                    strcpy(profile->SecurityMode, "wpa-wpa2-psk");
+                } else {
+                    fprintf(stderr, "Unknown auth mode arrived\n");
+                    break;
+                }
+            } else if (strcmp(sec_type, "11i") == 0) {
+                if (strcmp(auth_mode, "PSKAuthentication") == 0) {
+                    strcpy(profile->SecurityMode, "wpa2-psk");
+                } else {
+                    fprintf(stderr, "Unknown auth mode arrived\n");
+                    break;
+                }
+            } else {
+                fprintf(stderr, "Unknown sec type arrived\n");
+                break;
+            }
+            free(value);
+        } else if (strcmp(update->type, "KeyPassphrase") == 0) {
+            profile_split(emctl, i, ssid_index);
             strncpy(profile->KeyPassphrase, update->value, sizeof(profile->KeyPassphrase) - 1);
+        } else if (strcmp(update->type, "RadioEnable") == 0) {
+            return 0;
+        } else if (strcmp(update->type, "AutoChannelEnable") == 0) {
+            return 0;
+        } else if (strcmp(update->type, "Channel") == 0) {
+            return 0;
+        } else if (strcmp(update->type, "ChannelMode") == 0) {
+            return 0;
         } else {
             fprintf(stderr, "Unknown update arrived\n");
             break;
@@ -1263,11 +1342,12 @@ static void profile_update(PCOSA_DML_EMCTL_CFG emctl, update_params_t *update)
         break;
     }
 
-    return;
+    return 1;
 }
 
 static void *update_handler(void *farg)
 {
+    UNREFERENCED_PARAMETER(farg);
     struct timeval tval;
     struct timespec tspec;
     update_params_t *update;
@@ -1338,7 +1418,10 @@ int EmctlConfigChangeCB(char *context)
     }
 
     pthread_mutex_lock(&g_emctl_mutex);
-    profile_update(g_pEmctl_Cfg, update);
+    notify_needed = profile_update(g_pEmctl_Cfg, update);
+    if (notify_needed == false) {
+        return 0;
+    }
     if (g_pEmctl_Cfg->updating) {
         queue_push(g_pEmctl_Cfg->updates, update);
         pthread_cond_signal(&g_emctl_cond);

--- a/source/cosa_emctl_apis.c
+++ b/source/cosa_emctl_apis.c
@@ -1387,6 +1387,7 @@ static void *update_handler(void *farg)
 int EmctlConfigChangeCB(char *context)
 {
     update_params_t *update;
+    bool notify_needed;
     char *p_tok, *st;
     pthread_attr_t attr;
     pthread_attr_t *attrp = NULL;

--- a/source/cosa_emctl_apis.h
+++ b/source/cosa_emctl_apis.h
@@ -122,8 +122,12 @@ struct _COSA_DML_EMCTL_PROFILE_CFG {
 typedef struct _COSA_DML_EMCTL_PROFILE_CFG COSA_DML_EMCTL_PROFILE_CFG, *PCOSA_DML_EMCTL_PROFILE_CFG;
 
 struct _COSA_DML_EMCTL_CFG {
+    char                        AllowedBandwidth2G[COSA_EMCTL_MAX_CHANNEL_SET];
+    char                        AllowedBandwidth5G[COSA_EMCTL_MAX_CHANNEL_SET];
+    char                        AllowedBandwidth6G[COSA_EMCTL_MAX_CHANNEL_SET];
     char                        AllowedChannelList2G[COSA_EMCTL_MAX_CHANNEL_SET];
     char                        AllowedChannelList5G[COSA_EMCTL_MAX_CHANNEL_SET];
+    char                        AllowedChannelList6G[COSA_EMCTL_MAX_CHANNEL_SET];
     char                        BandLock5G[COSA_EMCTL_MAX_CHANNEL_SET];
     ULONG                       ConfigRenewInterval;
     ULONG                       ConfigRenewMaxRetry;
@@ -131,6 +135,7 @@ struct _COSA_DML_EMCTL_CFG {
     ULONG                       DeadAgentDetectionInterval;
     char                        Default2GPreferredChannelList[COSA_EMCTL_MAX_CHANNEL_SET];
     char                        Default5GPreferredChannelList[COSA_EMCTL_MAX_CHANNEL_SET];
+    char                        Default6GPreferredChannelList[COSA_EMCTL_MAX_CHANNEL_SET];
     ULONG                       DefaultPCP;
     BOOL                        Enable;
     char                        InterfaceList[COSA_EMCTL_MAX_IFLIST_LEN];
@@ -156,8 +161,12 @@ typedef struct _COSA_DML_EMCTL_CFG COSA_DML_EMCTL_CFG, *PCOSA_DML_EMCTL_CFG;
 ANSC_HANDLE CosaEmctlCreate(void);
 ANSC_STATUS CosaEmctlInitialize(ANSC_HANDLE hThisObject);
 
+int CosaEmctlGetAllowedBandwidth2G(char *value);
+int CosaEmctlGetAllowedBandwidth5G(char *value);
+int CosaEmctlGetAllowedBandwidth6G(char *value);
 int CosaEmctlGetAllowedChannelList2G(char *value);
 int CosaEmctlGetAllowedChannelList5G(char *value);
+int CosaEmctlGetAllowedChannelList6G(char *value);
 int CosaEmctlGetBandLock5G(char *value);
 int CosaEmctlGetConfigRenewInterval(unsigned int *value);
 int CosaEmctlGetConfigRenewMaxRetry(unsigned int *value);
@@ -165,6 +174,7 @@ int CosaEmctlGetConfigureBackhaulStation(uint8_t *value);
 int CosaEmctlGetDeadAgentDetectionInterval(unsigned int *value);
 int CosaEmctlGetDefault2GPreferredChannelList(char *value);
 int CosaEmctlGetDefault5GPreferredChannelList(char *value);
+int CosaEmctlGetDefault6GPreferredChannelList(char *value);
 int CosaEmctlGetDefaultPCP(uint8_t *value);
 int CosaEmctlGetEnable(unsigned int *value);
 int CosaEmctlGetInterfaceList(char *value);

--- a/source/cosa_emctl_dml.c
+++ b/source/cosa_emctl_dml.c
@@ -97,6 +97,7 @@ EasyMeshController_GetParamUlongValue
         ULONG*                      puLong
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "ConfigRenewInterval", TRUE)) {
@@ -177,6 +178,7 @@ EasyMeshController_GetParamBoolValue
         BOOL*                       pBool
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "ConfigureBackhaulStation", TRUE)) {
@@ -242,6 +244,7 @@ EasyMeshController_GetParamStringValue
         ULONG*                      pulSize
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "InterfaceList", TRUE)) {
@@ -326,6 +329,7 @@ EasyMeshController_GetParamIntValue
         int*                      	 pInt
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "PrimaryVLANID", TRUE)) {
@@ -374,6 +378,7 @@ EasyMeshController_SetParamUlongValue
         ULONG                       uValue
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "ConfigRenewInterval", TRUE)) {
@@ -482,6 +487,7 @@ EasyMeshController_SetParamStringValue
         char*                       pString
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "InterfaceList", TRUE)) {
@@ -563,6 +569,7 @@ EasyMeshController_SetParamBoolValue
         BOOL                        bValue
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "ConfigureBackhaulStation", TRUE)) {
@@ -628,6 +635,7 @@ EasyMeshController_SetParamIntValue
         int                         iValue
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "PrimaryVLANID", TRUE)) {
@@ -680,6 +688,10 @@ EasyMeshController_Validate
         ULONG*                      puLength
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
+    UNREFERENCED_PARAMETER(pReturnParamName);
+    UNREFERENCED_PARAMETER(puLength);
+
     return TRUE;
 }
 
@@ -711,6 +723,8 @@ EasyMeshController_Commit
         ANSC_HANDLE                 hInsContext
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
+
     return 0;
 }
 
@@ -743,6 +757,8 @@ EasyMeshController_Rollback
         ANSC_HANDLE                 hInsContext
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
+
     return 0;
 }
 
@@ -752,8 +768,8 @@ EasyMeshController_Rollback
 
     EasyMeshController.ChanSel.
 
-    *  ChanSel_GetParamBoolValue
     *  ChanSel_GetParamStringValue
+    *  ChanSel_SetParamStringValue
 
 **********************************************************************/
 /**********************************************************************
@@ -803,6 +819,7 @@ ChanSel_GetParamStringValue
         ULONG*                      pulSize
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "AllowedChannelList2G", TRUE)) {
@@ -892,6 +909,7 @@ ChanSel_SetParamStringValue
         char*                       pString
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
     PCOSA_DML_EMCTL_CFG cfg = g_pEmctl_Cfg;
 
     if (AnscEqualString(pParamName, "AllowedChannelList2G", TRUE)) {
@@ -946,8 +964,6 @@ ChanSel_SetParamStringValue
 
     *  SSIDProfile_GetEntryCount
     *  SSIDProfile_GetEntry
-    *  SSIDProfile_AddEntry
-    *  SSIDProfile_DelEntry
     *  SSIDProfile_GetParamBoolValue
     *  SSIDProfile_GetParamStringValue
     *  SSIDProfile_GetParamIntValue
@@ -1043,77 +1059,70 @@ SSIDProfile_GetEntry
     return pProfile;
 }
 
-/**********************************************************************
+/**************************************************************************
 
     caller:     owner of this object
 
     prototype:
 
-        ANSC_HANDLE
-        SSIDProfile_AddEntry
+        BOOL
+        SSIDProfile_IsUpdatedSSIDProfile_Synchronize
             (
-                ANSC_HANDLE                 hInsContext,
-                ULONG*                      pInsNumber
+                ANSC_HANDLE                 hInsContext
             );
 
     description:
 
-        This function is called to add a new entry.
+        This function is checking whether the table is updated or not.
 
     argument:   ANSC_HANDLE                 hInsContext,
                 The instance handle;
 
-                ULONG*                      pInsNumber
-                The output instance number;
+    return:     TRUE or FALSE.
 
-    return:     The handle of new added entry.
-
-**********************************************************************/
-ANSC_HANDLE
-SSIDProfile_AddEntry
+**************************************************************************/
+BOOL
+SSIDProfile_IsUpdated
     (
-        ANSC_HANDLE                 hInsContext,
-        ULONG*                      pInsNumber
+        ANSC_HANDLE                 hInsContext
     )
 {
-    return NULL;
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    return TRUE;
 }
 
-/**********************************************************************
+/**************************************************************************
 
     caller:     owner of this object
 
     prototype:
 
         ULONG
-        SSIDProfile_DelEntry
+        SSIDProfile_Synchronize
             (
-                ANSC_HANDLE                 hInsContext,
-                ANSC_HANDLE                 hInstance
+                ANSC_HANDLE                 hInsContext
             );
 
     description:
 
-        This function is called to delete an exist entry.
+        This function is called to synchronize the table.
 
     argument:   ANSC_HANDLE                 hInsContext,
                 The instance handle;
 
-                ANSC_HANDLE                 hInstance
-                The exist entry handle;
-
     return:     The status of the operation.
 
-**********************************************************************/
+**************************************************************************/
 ULONG
-SSIDProfile_DelEntry
+SSIDProfile_Synchronize
     (
-        ANSC_HANDLE                 hInsContext,
-        ANSC_HANDLE                 hInstance
+        ANSC_HANDLE                 hInsContext
     )
 {
-    ANSC_STATUS                     returnStatus         = ANSC_STATUS_SUCCESS;
-    return returnStatus;
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    return ANSC_STATUS_SUCCESS;
 }
 
 /**********************************************************************
@@ -1596,6 +1605,10 @@ SSIDProfile_Validate
         ULONG*                      puLength
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
+    UNREFERENCED_PARAMETER(pReturnParamName);
+    UNREFERENCED_PARAMETER(puLength);
+
     return TRUE;
 }
 
@@ -1627,6 +1640,8 @@ SSIDProfile_Commit
         ANSC_HANDLE                 hInsContext
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
+
     return 0;
 }
 
@@ -1659,5 +1674,7 @@ SSIDProfile_Rollback
         ANSC_HANDLE                 hInsContext
     )
 {
+    UNREFERENCED_PARAMETER(hInsContext);
+
     return 0;
 }

--- a/source/cosa_emctl_dml.h
+++ b/source/cosa_emctl_dml.h
@@ -185,8 +185,6 @@ ChanSel_SetParamStringValue
 
     *  SSIDProfile_GetEntryCount
     *  SSIDProfile_GetEntry
-    *  SSIDProfile_AddEntry
-    *  SSIDProfile_DelEntry
     *  SSIDProfile_GetParamBoolValue
     *  SSIDProfile_GetParamStringValue
     *  SSIDProfile_GetParamIntValue
@@ -212,18 +210,16 @@ SSIDProfile_GetEntry
         ULONG*                      pInsNumber
     );
 
-ANSC_HANDLE
-SSIDProfile_AddEntry
+BOOL
+SSIDProfile_IsUpdated
     (
-        ANSC_HANDLE                 hInsContext,
-        ULONG*                      pInsNumber
+        ANSC_HANDLE                 hInsContext
     );
 
 ULONG
-SSIDProfile_DelEntry
+SSIDProfile_Synchronize
     (
-        ANSC_HANDLE                 hInsContext,
-        ANSC_HANDLE                 hInstance
+        ANSC_HANDLE                 hInsContext
     );
 
 BOOL

--- a/source/plugin_main.c
+++ b/source/plugin_main.c
@@ -90,6 +90,8 @@ COSA_Init
 
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_GetEntryCount", SSIDProfile_GetEntryCount);
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_GetEntry", SSIDProfile_GetEntry);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_IsUpdated", SSIDProfile_IsUpdated);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_Synchronize", SSIDProfile_Synchronize);
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_GetParamBoolValue", SSIDProfile_GetParamBoolValue);
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_SetParamBoolValue", SSIDProfile_SetParamBoolValue);
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "SSIDProfile_GetParamStringValue", SSIDProfile_GetParamStringValue);
@@ -112,7 +114,8 @@ COSA_IsObjectSupported
         char*                        pObjName
     )
 {
-    
+    UNREFERENCED_PARAMETER(pObjName);
+
     return TRUE;
 }
 

--- a/source/ssp_action.c
+++ b/source/ssp_action.c
@@ -256,6 +256,8 @@ ssp_CcdIfGetComponentName
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->Name;
 }
 
@@ -266,6 +268,8 @@ ssp_CcdIfGetComponentVersion
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->Version;
 }
 
@@ -276,6 +280,8 @@ ssp_CcdIfGetComponentAuthor
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->Author;
 }
 
@@ -286,6 +292,8 @@ ssp_CcdIfGetComponentHealth
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->Health;
 }
 
@@ -296,6 +304,8 @@ ssp_CcdIfGetComponentState
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->State;
 }
 
@@ -307,6 +317,8 @@ ssp_CcdIfGetLoggingEnabled
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->LogEnable;
 }
 
@@ -318,6 +330,8 @@ ssp_CcdIfSetLoggingEnabled
         BOOL                            bEnabled
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     if( g_pComponent_COMMON_emctl->LogEnable == bEnabled) return ANSC_STATUS_SUCCESS;
     g_pComponent_COMMON_emctl->LogEnable = bEnabled;
     if(bEnabled) g_iTraceLevel = (INT) g_pComponent_COMMON_emctl->LogLevel;
@@ -333,6 +347,8 @@ ssp_CcdIfGetLoggingLevel
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->LogLevel;
 }
 
@@ -344,6 +360,8 @@ ssp_CcdIfSetLoggingLevel
         ULONG                           LogLevel
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     if( g_pComponent_COMMON_emctl->LogLevel == LogLevel) return ANSC_STATUS_SUCCESS;
     g_pComponent_COMMON_emctl->LogLevel = LogLevel;
     if( g_pComponent_COMMON_emctl->LogEnable) g_iTraceLevel = (INT) g_pComponent_COMMON_emctl->LogLevel;
@@ -358,6 +376,8 @@ ssp_CcdIfGetMemMaxUsage
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_ulAllocatedSizePeak;
 }
 
@@ -368,6 +388,8 @@ ssp_CcdIfGetMemMinUsage
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
+
     return g_pComponent_COMMON_emctl->MemMinUsage;
 }
 
@@ -378,6 +400,7 @@ ssp_CcdIfGetMemConsumed
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
     LONG             size = 0;
 
     size = AnscGetComponentMemorySize(CCSP_COMPONENT_NAME_EMCTL);
@@ -394,6 +417,7 @@ ssp_CcdIfApplyChanges
         ANSC_HANDLE                     hThisObject
     )
 {
+    UNREFERENCED_PARAMETER(hThisObject);
     ANSC_STATUS                         returnStatus    = ANSC_STATUS_SUCCESS;
     /* Assume the parameter settings are committed immediately. */
     /* AnscSetTraceLevel((INT) g_pComponent_COMMON_emctl->LogLevel); */

--- a/source/ssp_main.c
+++ b/source/ssp_main.c
@@ -219,11 +219,12 @@ int ssp_main(int argc, char* argv[])
 {
     ANSC_STATUS                     returnStatus       = ANSC_STATUS_SUCCESS;
     BOOL                            bRunAsDaemon       = TRUE;
+#if defined(_ANSC_WINDOWSNT)
     int                             cmdChar            = 0;
+#endif
     int                             idx = 0;
 
     (void) bRunAsDaemon;
-    (void) cmdChar;
 
     extern ANSC_HANDLE bus_handle;
     char *subSys            = NULL;  

--- a/source/ssp_mbi.c
+++ b/source/ssp_mbi.c
@@ -116,7 +116,7 @@ ssp_Mbi_MessageBusEngage
         return returnStatus;
     }
 
-    CcspTraceInfo(("INFO: bus_handle: 0x%8p \n", bus_handle));
+    CcspTraceInfo(("INFO: bus_handle: %p\n", bus_handle));
     g_MessageBusHandle_Irep = bus_handle;
     AnscCopyString(g_SubSysPrefix_Irep, g_Subsystem);
 
@@ -187,6 +187,7 @@ ssp_Mbi_Initialize
         void * user_data
     )
 {
+    UNREFERENCED_PARAMETER(user_data);
     ANSC_STATUS             returnStatus    = ANSC_STATUS_SUCCESS;
 
     return ( returnStatus == ANSC_STATUS_SUCCESS ) ? 0 : 1;
@@ -199,6 +200,7 @@ ssp_Mbi_Finalize
         void*               user_data
     )
 {
+    UNREFERENCED_PARAMETER(user_data);
     ANSC_STATUS             returnStatus    = ANSC_STATUS_SUCCESS;
 
     returnStatus = ssp_cancel();
@@ -213,6 +215,8 @@ ssp_Mbi_Buscheck
         void*               user_data
     )
 {
+    UNREFERENCED_PARAMETER(user_data);
+
     return 0;
 }
 
@@ -224,6 +228,7 @@ ssp_Mbi_FreeResources
         void                * user_data
     )
 {
+    UNREFERENCED_PARAMETER(user_data);
     ANSC_STATUS             returnStatus    = ANSC_STATUS_SUCCESS;
 
     if ( priority == CCSP_COMMON_COMPONENT_FREERESOURCES_PRIORITY_Low )


### PR DESCRIPTION
Reason for change: Added missing notifications of connection related variable changes. Change notifications for radio variables have also been added as informative purposes. The latter do not change the flow on the WiFi agent.
Test Procedure: Use CLI or GUI to modify SSID Enable, Security ModeEnabled and Radio related variables.
Risks: Low

Signed-off-by: Engin Akca <engin.akca@airties.com>