### PR TITLE
REFPLTB-2773 : RPi4 64bit build is broken due to RdkEasyMeshController

### DIFF
--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -51,7 +51,10 @@ em_ctl_LDADD = ${top_builddir}/source/controller/src/libcontroller.a \
                ${top_builddir}/source/ieee1905/src/al/libal.a \
                ${top_builddir}/source/ieee1905/src/factory/libfactory.a \
                ${top_builddir}/source/ieee1905/src/common/libcommon.a \
-               ${top_builddir}/source/libplatform/src/libutils.a
+               ${top_builddir}/source/libplatform/src/libutils.a \
+	       -lrbus \
+	       -lcrypto \
+	       -ljson-c
 
 em_ctl_LDFLAGS = -ljson-c \
                  -lz \


### PR DESCRIPTION
Reason for change: In Rpi4-64, build issues are seen for rbus,json-c and crypto, these respective LDFLAGS working as expect if we add only in em_ctl_LDADD rather than LDFLAGS and in bbappend files Build issues are
(1) rdkb/components/opensource/ccsp/RdkEasyMeshController/source/controller/src/map_ctrl_cli.c:650: undefined reference to `json_object_put' 
(2) rpi4-oct20/build-raspberrypi4-64-rdk-broadband/tmp/work/aarch64-rdk-linux/rdk-easymesh-controller/5+git999-r0/recipe-sysroot/usr/lib/libccsp_common.so: undefined reference to symbol 'rbusProperty_Release'
 (3) rdk-easymesh-controller/5+git999-r0/recipe-sysroot-native/usr/bin/aarch64-rdk-linux/../../libexec/aarch64-rdk-linux/gcc/aarch64-rdk-linux/9.3.0/ld: ../../source/ieee1905/src/al/libal.a(libal_a-platform_crypto.o): undefined reference to symbol 'HMAC_Final@@OPENSSL_1_1_0'
Test Procedure: bitbake rdk-easymesh-controller
Risks: Low